### PR TITLE
Fix IE

### DIFF
--- a/app/controllers/uploaded_files_controller.rb
+++ b/app/controllers/uploaded_files_controller.rb
@@ -1,5 +1,12 @@
 class UploadedFilesController < ApplicationController
   def file_upload
+    # FIX IE
+    if request.headers["HTTP_ACCEPT"].split(",").map(&:strip).include?("application/json")
+      content_type = "application/json"
+    else
+      content_type = "text/plain"
+    end
+
     uploaded_file = UploadedFile.new(file: params[:files][0])
     if uploaded_file.save
       render json: {
@@ -11,13 +18,13 @@ class UploadedFilesController < ApplicationController
             "id" => uploaded_file.id
           }
         ]
-      }
+      }, content_type: content_type
     else
       render json: {
         error: {
           "message" => "An error prevents the uploaded file to be saved"
         }
-      }
+      }, content_type: content_type
     end
   end
 end

--- a/lib/ouvrages_file_uploader/version.rb
+++ b/lib/ouvrages_file_uploader/version.rb
@@ -1,3 +1,3 @@
 module OuvragesFileUploader
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
IE n'accepte pas le format "application/json". Donc on envoit la réponse en "text/plain" si dans le headers, "application/json" n'est pas listé parmi les formats acceptés.